### PR TITLE
Move site URL to heypenny.money

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-heypenny.moelten.io
+heypenny.money

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Heypenny marketing site
 
-<https://heypenny.moelten.io>
+<https://heypenny.money>
 
-The Heypenny marketing website, hosted on Cloudflare pages.
+The Heypenny marketing website, hosted on DigitalOcean App Platform.

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,8 @@ site: Heypenny
 title: Heypenny
 email: support@moelten.io
 baseurl: ""
-url: https://heypenny.moelten.io
-domain: heypenny.moelten.io
+url: https://heypenny.money
+domain: heypenny.money
 
 collections:
   pages:

--- a/robots.txt
+++ b/robots.txt
@@ -13,4 +13,4 @@ Disallow: /
 User-agent: Omgilibot
 Disallow: /
 
-Sitemap: https://heypenny.moelten.io/sitemap.xml
+Sitemap: https://heypenny.money/sitemap.xml


### PR DESCRIPTION
Make the main site heypenny.money (links to heypenny.moelten.io will still work). This mainly affects the sitemap / SEO stuff.