### PR TITLE
Add /stickers redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,12 @@ status = 302
 force = true
 
 [[redirects]]
+from = "/sticker"
+to = "/?r=sticker"
+status = 302
+force = true
+
+[[redirects]]
 from = "/a/static/*"
 to = "https://us-assets.i.posthog.com/static/:splat"
 host = "us-assets.i.posthog.com"


### PR DESCRIPTION
I ordered stickers with a QR code on them, this redirects those to the homepage with tracking